### PR TITLE
Fix timer desync when stopping mid experiment

### DIFF
--- a/Assets/Src/ConditionningRunner.cs
+++ b/Assets/Src/ConditionningRunner.cs
@@ -34,6 +34,7 @@ public class Timer
 
         public void Stop() {
             is_on = false;
+            Reset_timer();
         }
 
         private void Mod_curr_time( float time ) {
@@ -516,6 +517,13 @@ public class ConditionningRunner : MonoBehaviour
             CS_timer.Start();
         }
 
+        private void Stop_all_timers() {
+            Prep_phase_timer.Stop();
+            CS_timer.Stop();
+            Trial_timer.Stop();
+            US_Timer.Stop();
+        }
+
 
         public void Stop() {
             if( Power_on ) {// No need to do anythhing if the XP is not running
@@ -537,6 +545,7 @@ public class ConditionningRunner : MonoBehaviour
                 ToggleFullScreenStim( false );
                 Spawn_Stim( false, all_stim_flag );
                 Reset_Choice();
+                Stop_all_timers();
             }
         }
 


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix timer desync when stopping mid experiment"

#### Purpose of change

Sometimes timer got messed when experiments were stop during the pre phase

#### Describe the solution

Make sure to always stop and reset all timer when the experiment is stopped

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Start experiment, stop and restart at different phase of the experiment
No issue
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
